### PR TITLE
Add auto-recognition feature for continuous background song identification

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -80,6 +80,40 @@
             </intent-filter>
         </service>
 
+        <!-- Auto-recognition launcher activity -->
+        <activity
+            android:name=".feature.recognition.service.AutoRecognitionLauncherActivity"
+            android:exported="false"
+            android:theme="@style/Theme.MusicRecognizer.Invisible"
+            android:excludeFromRecents="true"
+            android:noHistory="true"
+            android:taskAffinity="" />
+
+        <!-- Auto-recognition service -->
+        <service
+            android:name=".feature.recognition.service.AutoRecognitionService"
+            android:exported="false"
+            android:foregroundServiceType="microphone" />
+
+        <!-- Auto-recognition quick settings tile -->
+        <service
+            android:name=".feature.recognition.service.AutoRecognitionTileService"
+            android:exported="true"
+            android:icon="@drawable/ic_auto_recognize"
+            android:label="@string/auto_recognize_tile_inactive"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="false" />
+            <meta-data
+                android:name="android.service.quicksettings.TOGGLEABLE_TILE"
+                android:value="true" />
+
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
+
         <receiver
             android:name=".feature.recognition.service.DisableRecognitionControlServiceReceiver"
             android:exported="false" />

--- a/app/src/main/java/com/mrsep/musicrecognizer/presentation/MainActivity.kt
+++ b/app/src/main/java/com/mrsep/musicrecognizer/presentation/MainActivity.kt
@@ -26,19 +26,25 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import com.mrsep.musicrecognizer.core.domain.preferences.PreferencesRepository
 import com.mrsep.musicrecognizer.core.domain.preferences.ThemeMode
 import com.mrsep.musicrecognizer.core.ui.theme.MusicRecognizerTheme
 import com.mrsep.musicrecognizer.feature.recognition.service.RecognitionControlService
+import com.mrsep.musicrecognizer.feature.recognition.service.AutoRecognitionService
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
     private val viewModel: MainActivityViewModel by viewModels()
     private var isServiceStartupHandled = false
+
+    @Inject
+    lateinit var preferencesRepository: PreferencesRepository
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
@@ -55,6 +61,7 @@ class MainActivity : ComponentActivity() {
         if (savedInstanceState == null) {
             handleRecognitionRequest(intent)
         }
+        resetStaleAutoRecognizePreference()
         startControlServiceOnDemand()
         enableEdgeToEdge()
         setContent {
@@ -106,6 +113,15 @@ class MainActivity : ComponentActivity() {
             ACTION_MAIN -> {
                 if (intent.getBooleanExtra(KEY_RESTART_ON_BACKUP_RESTORE, false)) return
                 viewModel.requestRecognitionOnStartupIfPreferred()
+            }
+        }
+    }
+
+    // Reset autoRecognizeEnabled preference if service isn't actually running (e.g., after reinstall)
+    private fun resetStaleAutoRecognizePreference() {
+        if (!AutoRecognitionService.isRunning) {
+            lifecycleScope.launch {
+                preferencesRepository.setAutoRecognizeEnabled(false)
             }
         }
     }

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -30,4 +30,9 @@
         <item name="android:windowAnimationStyle">@android:style/Animation</item>
     </style>
 
+    <style name="Theme.MusicRecognizer.Invisible" parent="Theme.MusicRecognizer.Translucent">
+        <item name="android:windowAnimationStyle">@null</item>
+        <item name="android:windowDisablePreview">true</item>
+    </style>
+
 </resources>

--- a/core/data/src/main/java/com/mrsep/musicrecognizer/core/data/preferences/PreferencesRepositoryImpl.kt
+++ b/core/data/src/main/java/com/mrsep/musicrecognizer/core/data/preferences/PreferencesRepositoryImpl.kt
@@ -126,6 +126,10 @@ internal class PreferencesRepositoryImpl @Inject constructor(
         safeWriter { showCreationDateInQueue = value }
     }
 
+    override suspend fun setAutoRecognizeEnabled(value: Boolean) {
+        safeWriter { autoRecognizeEnabled = value }
+    }
+
     override suspend fun setThemeMode(value: ThemeMode) {
         safeWriter { themeMode = value.toProto() }
     }

--- a/core/data/src/main/java/com/mrsep/musicrecognizer/core/data/preferences/PreferencesToDomainMapper.kt
+++ b/core/data/src/main/java/com/mrsep/musicrecognizer/core/data/preferences/PreferencesToDomainMapper.kt
@@ -112,6 +112,7 @@ internal fun UserPreferencesProto.toDomain() = UserPreferences(
     useGridForRecognitionQueue = useGridForRecognitionQueue,
     showRecognitionDateInLibrary = showRecognitionDateInLibrary,
     showCreationDateInQueue = showCreationDateInQueue,
+    autoRecognizeEnabled = autoRecognizeEnabled,
     themeMode = when (themeMode!!) {
         UserPreferencesProto.ThemeModeProto.FOLLOW_SYSTEM -> ThemeMode.FollowSystem
         UserPreferencesProto.ThemeModeProto.ALWAYS_LIGHT -> ThemeMode.AlwaysLight
@@ -126,7 +127,8 @@ internal fun AudioCaptureModeProto.toDomain() = when (this) {
     AudioCaptureModeProto.Microphone -> AudioCaptureMode.Microphone
     AudioCaptureModeProto.Device -> AudioCaptureMode.Device
     AudioCaptureModeProto.Auto -> AudioCaptureMode.Auto
-    AudioCaptureModeProto.UNRECOGNIZED -> error("Unexpected proto value")
+    AudioCaptureModeProto.AutoRecognizer -> AudioCaptureMode.AutoRecognizer
+    AudioCaptureModeProto.UNRECOGNIZED -> AudioCaptureMode.Microphone
 }
 
 internal fun UserPreferencesProto.FallbackActionProto.toDomain() = when (this) {

--- a/core/data/src/main/java/com/mrsep/musicrecognizer/core/data/preferences/PreferencesToProtoMapper.kt
+++ b/core/data/src/main/java/com/mrsep/musicrecognizer/core/data/preferences/PreferencesToProtoMapper.kt
@@ -45,6 +45,7 @@ internal fun AudioCaptureMode.toProto() = when (this) {
     AudioCaptureMode.Microphone -> AudioCaptureModeProto.Microphone
     AudioCaptureMode.Device -> AudioCaptureModeProto.Device
     AudioCaptureMode.Auto -> AudioCaptureModeProto.Auto
+    AudioCaptureMode.AutoRecognizer -> AudioCaptureModeProto.AutoRecognizer
 }
 
 internal fun FallbackAction.toProto() = when (this) {

--- a/core/datastore/src/main/proto/audio_capture_mode_proto.proto
+++ b/core/datastore/src/main/proto/audio_capture_mode_proto.proto
@@ -8,4 +8,5 @@ enum AudioCaptureModeProto {
     Microphone = 1;
     Device = 2;
     Auto = 3;
+    AutoRecognizer = 4;
 }

--- a/core/datastore/src/main/proto/user_preferences_proto.proto
+++ b/core/datastore/src/main/proto/user_preferences_proto.proto
@@ -129,6 +129,8 @@ message UserPreferencesProto {
 
   optional bool use_alt_device_sound_source = 47;
 
-  // NEXT AVAILABLE ID: 48
+  bool auto_recognize_enabled = 48;
+
+  // NEXT AVAILABLE ID: 49
 
 }

--- a/core/domain/src/main/java/com/mrsep/musicrecognizer/core/domain/preferences/PreferencesRepository.kt
+++ b/core/domain/src/main/java/com/mrsep/musicrecognizer/core/domain/preferences/PreferencesRepository.kt
@@ -28,6 +28,7 @@ interface PreferencesRepository {
     suspend fun setUseGridForRecognitionQueue(value: Boolean)
     suspend fun setShowRecognitionDateInLibrary(value: Boolean)
     suspend fun setShowCreationDateInQueue(value: Boolean)
+    suspend fun setAutoRecognizeEnabled(value: Boolean)
     suspend fun setThemeMode(value: ThemeMode)
     suspend fun setUsePureBlackForDarkTheme(value: Boolean)
 }

--- a/core/domain/src/main/java/com/mrsep/musicrecognizer/core/domain/preferences/UserPreferences.kt
+++ b/core/domain/src/main/java/com/mrsep/musicrecognizer/core/domain/preferences/UserPreferences.kt
@@ -24,11 +24,12 @@ data class UserPreferences(
     val useGridForRecognitionQueue: Boolean,
     val showRecognitionDateInLibrary: Boolean,
     val showCreationDateInQueue: Boolean,
+    val autoRecognizeEnabled: Boolean,
     val themeMode: ThemeMode,
     val usePureBlackForDarkTheme: Boolean,
 )
 
-enum class AudioCaptureMode { Microphone, Device, Auto }
+enum class AudioCaptureMode { Microphone, Device, Auto, AutoRecognizer }
 
 enum class FallbackAction(val save: Boolean, val launch: Boolean) {
 

--- a/core/strings/src/main/res/values/strings.xml
+++ b/core/strings/src/main/res/values/strings.xml
@@ -200,6 +200,7 @@
     <string name="audio_capture_mode_microphone">Microphone</string>
     <string name="audio_capture_mode_device">Device audio</string>
     <string name="audio_capture_mode_auto">Automatic</string>
+    <string name="audio_capture_mode_auto_recognizer">Auto Recognition</string>
     <string name="audio_source_dialog_use_alt_device_source">Use alternative device audio source</string>
     <string name="pref_title_fallback_policy">Recognition fallback policy</string>
     <string name="pref_subtitle_fallback_policy">Set fallback actions after unsuccessful recognitions</string>
@@ -309,6 +310,21 @@
     <string name="notification_channel_desc_background_result">Shows song results when the app is minimized or you’re not on the recognition screen</string>
     <string name="notification_channel_name_scheduled_result">Song results of scheduled recognitions</string>
     <string name="notification_channel_desc_scheduled_result">Shows song results of recognitions that were scheduled offline or in other cases</string>
+
+    <!-- Auto-recognize feature -->
+    <string name="auto_recognize_notification_channel_name">Auto-recognition service</string>
+    <string name="auto_recognize_notification_channel_desc">Continuous background music recognition</string>
+    <string name="auto_recognize_notification_title">Auto Recognition is on</string>
+    <string name="auto_recognize_notification_text">Continuously identifies songs around you</string>
+    <string name="auto_recognize_toast_on">Auto Recognition is on</string>
+    <string name="auto_recognize_toast_off">Auto Recognition is off</string>
+    <string name="auto_recognize_tile_active">Auto Recognition</string>
+    <string name="auto_recognize_tile_inactive">Auto Recognition</string>
+    <string name="auto_recognize_result_channel_name">Auto-recognition results</string>
+    <string name="auto_recognize_result_channel_desc">Shows recognized songs from auto-recognition</string>
+    <string name="auto_recognize_songs_recognized">%d songs recognized</string>
+    <string name="auto_recognize_button_active">Auto Recognition is on</string>
+    <string name="auto_recognize_tap_to_turn_off">Tap to turn off</string>
 
     <string name="crash_dialog_title">Audile has crashed</string>
     <string name="crash_dialog_message">An unexpected error has occurred, causing the app to stop. Would you like to email the bug report to help fix the issue\?</string>

--- a/core/ui/src/main/res/drawable/ic_auto_recognize.xml
+++ b/core/ui/src/main/res/drawable/ic_auto_recognize.xml
@@ -1,0 +1,29 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <!-- Outer circle - thin, at the edge -->
+  <path
+      android:pathData="M12,0.5C5.65,0.5 0.5,5.65 0.5,12C0.5,18.35 5.65,23.5 12,23.5C18.35,23.5 23.5,18.35 23.5,12C23.5,5.65 18.35,0.5 12,0.5Z"
+      android:strokeWidth="0.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#FFFFFF"/>
+  <!-- Inner circle - medium thickness -->
+  <path
+      android:pathData="M12,2.2C6.59,2.2 2.2,6.59 2.2,12C2.2,17.41 6.59,21.8 12,21.8C17.41,21.8 21.8,17.41 21.8,12C21.8,6.59 17.41,2.2 12,2.2Z"
+      android:strokeWidth="0.85"
+      android:fillColor="#00000000"
+      android:strokeColor="#FFFFFF"/>
+  <!-- Microphone (scaled larger) -->
+  <group
+      android:scaleX="0.7"
+      android:scaleY="0.7"
+      android:pivotX="12"
+      android:pivotY="12">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="m14.735,9.531h4.558l-0,-1.823h-4.558c-1.216,0 -1.216,-1.823 0,-1.823l4.467,-0C18.769,3.761 16.901,2.237 14.735,2.237l-5.47,-0C7.099,2.237 5.231,3.761 4.798,5.884l4.467,-0c1.216,0 1.216,1.823 0,1.823H4.707v1.823h4.558c1.216,0 1.216,1.823 0,1.823H4.707l-0,1.823h4.558c1.215,0.001 1.215,1.824 0,1.823H4.707l-0,0.912c0,2.204 1.578,4.093 3.747,4.485 0.307,0.621 1.054,2.483 3.51,2.491 2.547,-0.008 3.284,-1.849 3.583,-2.491 2.169,-0.392 3.747,-2.281 3.747,-4.485v-0.912h-4.558c-1.215,-0.001 -1.215,-1.824 0,-1.823h4.558v-1.823h-4.558c-1.214,-0.001 -1.214,-1.822 0,-1.823zM10.177,19.559c0,-1.625 1.964,-2.438 3.113,-1.289 1.149,1.149 0.335,3.113 -1.289,3.113 -1.007,0 -1.823,-0.816 -1.823,-1.823z"
+        android:strokeWidth="1.3"/>
+  </group>
+</vector>

--- a/feature/preferences/src/main/java/com/mrsep/musicrecognizer/feature/preferences/presentation/AudioSourceDialog.kt
+++ b/feature/preferences/src/main/java/com/mrsep/musicrecognizer/feature/preferences/presentation/AudioSourceDialog.kt
@@ -57,6 +57,8 @@ internal fun AudioSourceDialog(
     onChangeUseAltDeviceSoundSource: (Boolean) -> Unit,
     onDismissClick: () -> Unit,
 ) {
+    val availableOptions = AudioCaptureMode.entries.toImmutableList()
+
     AlertDialog(
         title = {
             Text(text = stringResource(StringsR.string.audio_source_dialog_title))
@@ -75,7 +77,7 @@ internal fun AudioSourceDialog(
                 Text(text = stringResource(StringsR.string.audio_source_dialog_default_mode_message))
                 Spacer(Modifier.height(16.dp))
                 AudioCaptureModeDropdownMenu(
-                    modes = allOptions,
+                    modes = availableOptions.filter { it != AudioCaptureMode.AutoRecognizer }.toImmutableList(),
                     label = stringResource(StringsR.string.audio_source_dialog_default_mode_title),
                     selectedMode = defaultAudioCaptureMode,
                     onSelectMode = onChangeDefaultAudioCaptureMode,
@@ -84,7 +86,7 @@ internal fun AudioSourceDialog(
                 Text(text = stringResource(StringsR.string.audio_source_dialog_button_long_press_mode_message))
                 Spacer(Modifier.height(16.dp))
                 AudioCaptureModeDropdownMenu(
-                    modes = allOptions,
+                    modes = availableOptions,
                     label = stringResource(StringsR.string.audio_source_dialog_button_long_press_mode_title),
                     selectedMode = mainButtonLongPressAudioCaptureMode,
                     onSelectMode = onChangeMainButtonLongPressAudioCaptureMode,
@@ -183,14 +185,13 @@ private fun AudioCaptureModeDropdownMenu(
     }
 }
 
-private val allOptions = AudioCaptureMode.entries.toImmutableList()
-
 @Composable
 private fun AudioCaptureMode.getTitle(): String {
     return when (this) {
         AudioCaptureMode.Microphone -> stringResource(StringsR.string.audio_capture_mode_microphone)
         AudioCaptureMode.Device -> stringResource(StringsR.string.audio_capture_mode_device)
         AudioCaptureMode.Auto -> stringResource(StringsR.string.audio_capture_mode_auto)
+        AudioCaptureMode.AutoRecognizer -> stringResource(StringsR.string.audio_capture_mode_auto_recognizer)
     }
 }
 

--- a/feature/recognition/src/main/java/com/mrsep/musicrecognizer/feature/recognition/presentation/recognitionscreen/RecognitionButtonWithTitle.kt
+++ b/feature/recognition/src/main/java/com/mrsep/musicrecognizer/feature/recognition/presentation/recognitionscreen/RecognitionButtonWithTitle.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.clickable
 import com.mrsep.musicrecognizer.core.strings.R as StringsR
 
 @Composable
@@ -27,7 +28,9 @@ internal fun RecognitionButtonWithTitle(
     soundLevelState: State<Float>,
     onButtonClick: () -> Unit,
     onButtonLongClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    autoRecognizeActive: Boolean = false,
+    onAutoRecognizeTap: (() -> Unit)? = null,
 ) {
     Column(
         modifier = modifier,
@@ -36,7 +39,7 @@ internal fun RecognitionButtonWithTitle(
     ) {
         AnimatedContent(
             contentAlignment = Alignment.Center,
-            targetState = title,
+            targetState = autoRecognizeActive,
             transitionSpec = {
                 (slideIntoContainer(
                     towards = AnimatedContentTransitionScope.SlideDirection.Up,
@@ -53,18 +56,37 @@ internal fun RecognitionButtonWithTitle(
                 )
             },
             label = "buttonTitleTransition"
-        ) {
-            Text(
-                text = it,
-                style = MaterialTheme.typography.headlineMedium.copy(
-                    fontWeight = FontWeight.Medium
-                ),
-                textAlign = TextAlign.Center,
+        ) { isAutoActive ->
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier
                     .clearAndSetSemantics { }
                     .fillMaxWidth()
+                    .let { mod ->
+                        if (isAutoActive) mod.clickable { onAutoRecognizeTap?.invoke() }
+                        else mod
+                    }
                     .padding(bottom = 40.dp)
-            )
+            ) {
+                Text(
+                    text = if (isAutoActive) stringResource(StringsR.string.auto_recognize_button_active) else title,
+                    style = MaterialTheme.typography.headlineMedium.copy(
+                        fontWeight = FontWeight.Medium
+                    ),
+                    textAlign = TextAlign.Center,
+                )
+                if (isAutoActive) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = stringResource(StringsR.string.auto_recognize_tap_to_turn_off),
+                        style = MaterialTheme.typography.bodyLarge.copy(
+                            fontWeight = FontWeight.Normal
+                        ),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
         }
 
         RecognitionButton(

--- a/feature/recognition/src/main/java/com/mrsep/musicrecognizer/feature/recognition/presentation/recognitionscreen/RecognitionScreen.kt
+++ b/feature/recognition/src/main/java/com/mrsep/musicrecognizer/feature/recognition/presentation/recognitionscreen/RecognitionScreen.kt
@@ -36,6 +36,7 @@ import com.mrsep.musicrecognizer.core.ui.components.RecognitionPermissionsRation
 import com.mrsep.musicrecognizer.core.ui.findActivity
 import com.mrsep.musicrecognizer.core.ui.shouldShowRationale
 import com.mrsep.musicrecognizer.feature.recognition.BuildConfig
+import com.mrsep.musicrecognizer.feature.recognition.service.AutoRecognitionService
 import com.mrsep.musicrecognizer.feature.recognition.presentation.recognitionscreen.shields.ApiUsageLimitedShield
 import com.mrsep.musicrecognizer.feature.recognition.presentation.recognitionscreen.shields.AuthErrorShield
 import com.mrsep.musicrecognizer.feature.recognition.presentation.recognitionscreen.shields.BadConnectionShield
@@ -112,6 +113,9 @@ internal fun RecognitionScreen(
                         mediaProjectionLauncher.launch(intent)
                     }
                 }
+                AudioCaptureMode.AutoRecognizer -> {
+                    startAutoRecognizeService(context, viewModel)
+                }
             }
         } else {
             val activity = context.findActivity()
@@ -158,6 +162,9 @@ internal fun RecognitionScreen(
                         mediaProjectionLauncher.launch(intent)
                     }
                 }
+                AudioCaptureMode.AutoRecognizer -> {
+                    startAutoRecognizeService(context, viewModel)
+                }
             }
         } else if (requiredPermissionsState.shouldShowRationale) {
             showPermissionsRationaleDialog = true
@@ -198,9 +205,17 @@ internal fun RecognitionScreen(
                     .fillMaxSize()
                     .verticalScroll(rememberScrollState()),
             ) {
+                fun stopAutoRecognize() {
+                    viewModel.stopAutoRecognition()
+                    AutoRecognitionService.stop(context)
+                }
                 fun onClick(captureMode: AudioCaptureMode) {
                     if (recognizeStatus.isDone()) return
                     if (preferences.vibrateOnTap()) viewModel.vibrateOnTap()
+                    if (preferences?.autoRecognizeEnabled == true) {
+                        stopAutoRecognize()
+                        return
+                    }
                     if (recognizeStatus is RecognitionStatus.Recognizing) {
                         viewModel.cancelRecognition()
                     } else {
@@ -211,8 +226,10 @@ internal fun RecognitionScreen(
                     title = getButtonTitle(recognizeStatus, autostart),
                     onButtonClick = { defaultCaptureMode?.run(::onClick) },
                     onButtonLongClick = { longClickCaptureMode?.run(::onClick) },
-                    activated = recognizeStatus is RecognitionStatus.Recognizing,
+                    activated = recognizeStatus is RecognitionStatus.Recognizing || preferences?.autoRecognizeEnabled == true,
                     soundLevelState = soundLevelState,
+                    autoRecognizeActive = preferences?.autoRecognizeEnabled == true,
+                    onAutoRecognizeTap = { stopAutoRecognize() },
                     modifier = Modifier.padding(24.dp)
                 )
             }
@@ -487,4 +504,12 @@ private fun RemoteRecognitionResult.Error.getErrorInfo() = when (this) {
 
     is RemoteRecognitionResult.Error.UnhandledError ->
         "Message:\n$message\n\nCause:\n${cause?.stackTraceToString()}"
+}
+
+private fun startAutoRecognizeService(
+    context: android.content.Context,
+    viewModel: RecognitionViewModel
+) {
+    viewModel.startAutoRecognition()
+    AutoRecognitionService.start(context)
 }

--- a/feature/recognition/src/main/java/com/mrsep/musicrecognizer/feature/recognition/presentation/recognitionscreen/RecognitionViewModel.kt
+++ b/feature/recognition/src/main/java/com/mrsep/musicrecognizer/feature/recognition/presentation/recognitionscreen/RecognitionViewModel.kt
@@ -40,7 +40,7 @@ internal class RecognitionViewModel @Inject constructor(
     @MainScreenStatusHolder private val statusHolder: RecognitionStatusHolder,
     private val recognitionController: ScreenRecognitionController,
     private val vibrationManager: VibrationManager,
-    preferencesRepository: PreferencesRepository,
+    private val preferencesRepository: PreferencesRepository,
     networkMonitor: NetworkMonitor,
 ) : ViewModel() {
 
@@ -86,6 +86,18 @@ internal class RecognitionViewModel @Inject constructor(
 
     fun vibrateResult(isSuccess: Boolean) {
         vibrationManager.vibrateResult(isSuccess)
+    }
+
+    fun stopAutoRecognition() {
+        viewModelScope.launch {
+            preferencesRepository.setAutoRecognizeEnabled(false)
+        }
+    }
+
+    fun startAutoRecognition() {
+        viewModelScope.launch {
+            preferencesRepository.setAutoRecognizeEnabled(true)
+        }
     }
 }
 

--- a/feature/recognition/src/main/java/com/mrsep/musicrecognizer/feature/recognition/service/AutoRecognitionLauncherActivity.kt
+++ b/feature/recognition/src/main/java/com/mrsep/musicrecognizer/feature/recognition/service/AutoRecognitionLauncherActivity.kt
@@ -1,0 +1,81 @@
+package com.mrsep.musicrecognizer.feature.recognition.service
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
+
+private const val TAG = "AutoRecognitionLauncher"
+
+/**
+ * Transparent activity that brings the app to the foreground before starting
+ * AutoRecognitionService. This is required on Android 14+ because foreground
+ * services with microphone type cannot start from the background.
+ */
+class AutoRecognitionLauncherActivity : ComponentActivity() {
+
+    private val requestPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            startAutoRecognitionService()
+        } else {
+            Log.w(TAG, "RECORD_AUDIO permission denied")
+        }
+        finish()
+    }
+
+    @Suppress("DEPRECATION")
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        overridePendingTransition(0, 0)
+
+        when (intent?.action) {
+            ACTION_START -> {
+                if (ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO)
+                    == PackageManager.PERMISSION_GRANTED) {
+                    startAutoRecognitionService()
+                    finish()
+                    overridePendingTransition(0, 0)
+                } else {
+                    requestPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                }
+            }
+            ACTION_STOP -> {
+                AutoRecognitionService.stop(applicationContext)
+                finish()
+                overridePendingTransition(0, 0)
+            }
+            else -> {
+                finish()
+                overridePendingTransition(0, 0)
+            }
+        }
+    }
+
+    private fun startAutoRecognitionService() {
+        AutoRecognitionService.start(applicationContext)
+    }
+
+    companion object {
+        const val ACTION_START = "com.mrsep.musicrecognizer.auto_recognize.START"
+        const val ACTION_STOP = "com.mrsep.musicrecognizer.auto_recognize.STOP"
+
+        fun startIntent(context: Context): Intent {
+            return Intent(context, AutoRecognitionLauncherActivity::class.java)
+                .setAction(ACTION_START)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+
+        fun stopIntent(context: Context): Intent {
+            return Intent(context, AutoRecognitionLauncherActivity::class.java)
+                .setAction(ACTION_STOP)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+    }
+}

--- a/feature/recognition/src/main/java/com/mrsep/musicrecognizer/feature/recognition/service/AutoRecognitionService.kt
+++ b/feature/recognition/src/main/java/com/mrsep/musicrecognizer/feature/recognition/service/AutoRecognitionService.kt
@@ -1,0 +1,318 @@
+package com.mrsep.musicrecognizer.feature.recognition.service
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.util.Log
+import android.widget.Toast
+import androidx.core.app.NotificationCompat
+import com.mrsep.musicrecognizer.core.audio.audiorecord.AudioCaptureConfig
+import com.mrsep.musicrecognizer.core.audio.audiorecord.AudioRecordingControllerFactory
+import com.mrsep.musicrecognizer.core.domain.preferences.PreferencesRepository
+import com.mrsep.musicrecognizer.core.domain.recognition.RecognitionInteractor
+import com.mrsep.musicrecognizer.core.domain.recognition.model.RecognitionResult
+import com.mrsep.musicrecognizer.core.domain.recognition.model.RecognitionStatus
+import com.mrsep.musicrecognizer.core.domain.track.model.Track
+import coil3.ImageLoader
+import coil3.request.ImageRequest
+import coil3.request.allowHardware
+import coil3.size.Size
+import coil3.toBitmap
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.transformWhile
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import com.mrsep.musicrecognizer.core.strings.R as StringsR
+import com.mrsep.musicrecognizer.core.ui.R as UiR
+
+private const val TAG = "AutoRecognitionService"
+private const val NOTIFICATION_CHANNEL_ID = "com.mrsep.musicrecognizer.auto_recognition"
+private const val NOTIFICATION_CHANNEL_ID_RESULT = "com.mrsep.musicrecognizer.auto_recognition_result"
+private const val NOTIFICATION_ID = 100
+private const val NOTIFICATION_ID_SUMMARY = 101
+private const val NOTIFICATION_GROUP_KEY = "com.mrsep.musicrecognizer.AUTO_RECOGNIZE_GROUP"
+private const val RECOGNITION_INTERVAL_MS = 10000L
+
+@AndroidEntryPoint
+class AutoRecognitionService : Service() {
+
+    @Inject
+    lateinit var preferencesRepository: PreferencesRepository
+
+    @Inject
+    lateinit var recognitionInteractor: RecognitionInteractor
+
+    @Inject
+    lateinit var audioRecordingControllerFactory: AudioRecordingControllerFactory
+
+    private val serviceScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+    private val notificationManager by lazy { getSystemService(NotificationManager::class.java) }
+    private var recognitionJob: Job? = null
+    private var lastRecognizedTrackId: String? = null
+    private var notificationIdCounter = 1000
+    private var recognizedSongsCount = 0
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_START -> startAutoRecognition()
+            ACTION_STOP -> stopAutoRecognition()
+        }
+        return START_STICKY
+    }
+
+    private fun startAutoRecognition() {
+        try {
+            startForeground(NOTIFICATION_ID, createNotification())
+        } catch (e: SecurityException) {
+            Log.e(TAG, "Cannot start foreground service - missing permissions", e)
+            stopSelf()
+            return
+        }
+
+        isRunning = true
+
+        Handler(Looper.getMainLooper()).post {
+            Toast.makeText(
+                applicationContext,
+                getString(StringsR.string.auto_recognize_toast_on),
+                Toast.LENGTH_SHORT
+            ).show()
+        }
+
+        AutoRecognitionTileService.requestListeningState(this)
+
+        recognitionJob = serviceScope.launch {
+            while (isActive) {
+                try {
+                    performRecognition()
+                } catch (e: Exception) {
+                    Log.e(TAG, "Error during recognition", e)
+                }
+                delay(RECOGNITION_INTERVAL_MS)
+            }
+        }
+    }
+
+    private suspend fun performRecognition() {
+        val captureConfig = AudioCaptureConfig.Microphone
+        val audioController = audioRecordingControllerFactory.getAudioController(captureConfig)
+
+        recognitionInteractor.cancelAndJoin()
+
+        with(serviceScope) {
+            recognitionInteractor.launchRecognition(audioController)
+        }
+
+        recognitionInteractor.status.transformWhile { status ->
+            emit(status)
+            status !is RecognitionStatus.Done
+        }.collect { status ->
+            if (status is RecognitionStatus.Done) {
+                handleRecognitionResult(status.result)
+                recognitionInteractor.resetFinalStatus()
+            }
+        }
+    }
+
+    private suspend fun handleRecognitionResult(result: RecognitionResult) {
+        when (result) {
+            is RecognitionResult.Success -> {
+                val trackId = result.track.id
+                if (trackId != lastRecognizedTrackId) {
+                    lastRecognizedTrackId = trackId
+                    showSongNotification(result.track)
+                }
+            }
+            is RecognitionResult.Error -> {
+                Log.e(TAG, "Recognition error: ${result.remoteError}")
+            }
+            is RecognitionResult.NoMatches,
+            is RecognitionResult.ScheduledOffline -> { /* no-op */ }
+        }
+    }
+
+    private suspend fun showSongNotification(track: Track) {
+        recognizedSongsCount++
+        val notificationId = notificationIdCounter++
+        val timestamp = System.currentTimeMillis()
+
+        val notificationBuilder = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID_RESULT)
+            .setSmallIcon(UiR.drawable.ic_notification_ready)
+            .setContentTitle(track.title)
+            .setContentText(track.artist)
+            .setAutoCancel(true)
+            .setWhen(timestamp)
+            .setShowWhen(true)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setGroup(NOTIFICATION_GROUP_KEY)
+            .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY)
+
+        track.artworkThumbUrl?.let { artworkUrl ->
+            try {
+                val imageLoader = ImageLoader(this)
+                val request = ImageRequest.Builder(this)
+                    .data(artworkUrl)
+                    .size(Size(128, 128))
+                    .allowHardware(false)
+                    .build()
+                val result = imageLoader.execute(request)
+                result.image?.toBitmap()?.let { bitmap ->
+                    notificationBuilder.setLargeIcon(bitmap)
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to load artwork", e)
+            }
+        }
+
+        notificationManager.notify(notificationId, notificationBuilder.build())
+
+        val songsText = getString(StringsR.string.auto_recognize_songs_recognized, recognizedSongsCount)
+        val summaryNotification = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID_RESULT)
+            .setSmallIcon(UiR.drawable.ic_auto_recognize)
+            .setContentTitle(getString(StringsR.string.app_name))
+            .setContentText(songsText)
+            .setWhen(timestamp)
+            .setShowWhen(false)
+            .setGroup(NOTIFICATION_GROUP_KEY)
+            .setGroupSummary(true)
+            .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY)
+            .setAutoCancel(false)
+            .setOngoing(false)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setStyle(NotificationCompat.InboxStyle().setSummaryText(songsText))
+            .build()
+
+        notificationManager.notify(NOTIFICATION_ID_SUMMARY, summaryNotification)
+    }
+
+    private fun stopAutoRecognition() {
+        isRunning = false
+
+        Handler(Looper.getMainLooper()).post {
+            Toast.makeText(
+                applicationContext,
+                getString(StringsR.string.auto_recognize_toast_off),
+                Toast.LENGTH_SHORT
+            ).show()
+        }
+        recognitionJob?.cancel()
+        recognitionJob = null
+        lastRecognizedTrackId = null
+        notificationIdCounter = 1000
+        recognizedSongsCount = 0
+
+        serviceScope.launch {
+            preferencesRepository.setAutoRecognizeEnabled(false)
+        }
+
+        AutoRecognitionTileService.requestListeningState(this)
+
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        stopSelf()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        isRunning = false
+        serviceScope.cancel()
+    }
+
+    private fun createNotificationChannel() {
+        val serviceChannel = NotificationChannel(
+            NOTIFICATION_CHANNEL_ID,
+            getString(StringsR.string.auto_recognize_notification_channel_name),
+            NotificationManager.IMPORTANCE_LOW
+        ).apply {
+            description = getString(StringsR.string.auto_recognize_notification_channel_desc)
+            setShowBadge(false)
+        }
+        notificationManager.createNotificationChannel(serviceChannel)
+
+        val resultChannel = NotificationChannel(
+            NOTIFICATION_CHANNEL_ID_RESULT,
+            getString(StringsR.string.auto_recognize_result_channel_name),
+            NotificationManager.IMPORTANCE_HIGH
+        ).apply {
+            description = getString(StringsR.string.auto_recognize_result_channel_desc)
+            setShowBadge(true)
+        }
+        notificationManager.createNotificationChannel(resultChannel)
+    }
+
+    private fun createNotification(): Notification {
+        val stopIntent = Intent(this, AutoRecognitionService::class.java).apply {
+            action = ACTION_STOP
+        }
+        val stopPendingIntent = PendingIntent.getService(
+            this, 0, stopIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val deleteIntent = Intent(this, AutoRecognitionService::class.java).apply {
+            action = ACTION_STOP
+        }
+        val deletePendingIntent = PendingIntent.getService(
+            this, 1, deleteIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        return NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
+            .setSmallIcon(UiR.drawable.ic_auto_recognize)
+            .setContentTitle(getString(StringsR.string.auto_recognize_notification_title))
+            .setContentText(getString(StringsR.string.auto_recognize_notification_text))
+            .setOngoing(false)
+            .setDeleteIntent(deletePendingIntent)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .addAction(
+                android.R.drawable.ic_menu_close_clear_cancel,
+                getString(StringsR.string.cancel),
+                stopPendingIntent
+            )
+            .build()
+    }
+
+    companion object {
+        const val ACTION_START = "com.mrsep.musicrecognizer.AUTO_RECOGNIZE_START"
+        const val ACTION_STOP = "com.mrsep.musicrecognizer.AUTO_RECOGNIZE_STOP"
+
+        @Volatile
+        var isRunning: Boolean = false
+            private set
+
+        fun start(context: Context) {
+            val intent = Intent(context, AutoRecognitionService::class.java).apply {
+                action = ACTION_START
+            }
+            context.startForegroundService(intent)
+        }
+
+        fun stop(context: Context) {
+            val intent = Intent(context, AutoRecognitionService::class.java).apply {
+                action = ACTION_STOP
+            }
+            context.startService(intent)
+        }
+    }
+}

--- a/feature/recognition/src/main/java/com/mrsep/musicrecognizer/feature/recognition/service/AutoRecognitionService.kt
+++ b/feature/recognition/src/main/java/com/mrsep/musicrecognizer/feature/recognition/service/AutoRecognitionService.kt
@@ -7,6 +7,8 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+import android.os.Build
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
@@ -15,6 +17,7 @@ import android.widget.Toast
 import androidx.core.app.NotificationCompat
 import com.mrsep.musicrecognizer.core.audio.audiorecord.AudioCaptureConfig
 import com.mrsep.musicrecognizer.core.audio.audiorecord.AudioRecordingControllerFactory
+import com.mrsep.musicrecognizer.core.domain.preferences.AudioCaptureMode
 import com.mrsep.musicrecognizer.core.domain.preferences.PreferencesRepository
 import com.mrsep.musicrecognizer.core.domain.recognition.RecognitionInteractor
 import com.mrsep.musicrecognizer.core.domain.recognition.model.RecognitionResult
@@ -84,7 +87,12 @@ class AutoRecognitionService : Service() {
 
     private fun startAutoRecognition() {
         try {
-            startForeground(NOTIFICATION_ID, createNotification())
+            val notification = createNotification()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                startForeground(NOTIFICATION_ID, notification, FOREGROUND_SERVICE_TYPE_MICROPHONE)
+            } else {
+                startForeground(NOTIFICATION_ID, notification)
+            }
         } catch (e: SecurityException) {
             Log.e(TAG, "Cannot start foreground service - missing permissions", e)
             stopSelf()
@@ -116,16 +124,25 @@ class AutoRecognitionService : Service() {
     }
 
     private suspend fun performRecognition() {
-        val captureConfig = AudioCaptureConfig.Microphone
-        val audioController = audioRecordingControllerFactory.getAudioController(captureConfig)
+        Log.d(TAG, "Starting recognition cycle")
 
         recognitionInteractor.cancelAndJoin()
+
+        val userPreferences = preferencesRepository.userPreferencesFlow.first()
+        val captureConfig = when (userPreferences.defaultAudioCaptureMode) {
+            AudioCaptureMode.Microphone -> AudioCaptureConfig.Microphone
+            AudioCaptureMode.Device -> AudioCaptureConfig.Device(null)
+            AudioCaptureMode.Auto -> AudioCaptureConfig.Auto(null)
+            AudioCaptureMode.AutoRecognizer -> AudioCaptureConfig.Auto(null)
+        }
+        val audioController = audioRecordingControllerFactory.getAudioController(captureConfig)
 
         with(serviceScope) {
             recognitionInteractor.launchRecognition(audioController)
         }
 
         recognitionInteractor.status.transformWhile { status ->
+            Log.d(TAG, "Status update: $status")
             emit(status)
             status !is RecognitionStatus.Done
         }.collect { status ->
@@ -134,12 +151,14 @@ class AutoRecognitionService : Service() {
                 recognitionInteractor.resetFinalStatus()
             }
         }
+        Log.d(TAG, "Recognition cycle completed")
     }
 
     private suspend fun handleRecognitionResult(result: RecognitionResult) {
         when (result) {
             is RecognitionResult.Success -> {
                 val trackId = result.track.id
+                Log.d(TAG, "Recognition success: ${result.track.title} by ${result.track.artist}")
                 if (trackId != lastRecognizedTrackId) {
                     lastRecognizedTrackId = trackId
                     showSongNotification(result.track)
@@ -148,8 +167,12 @@ class AutoRecognitionService : Service() {
             is RecognitionResult.Error -> {
                 Log.e(TAG, "Recognition error: ${result.remoteError}")
             }
-            is RecognitionResult.NoMatches,
-            is RecognitionResult.ScheduledOffline -> { /* no-op */ }
+            is RecognitionResult.NoMatches -> {
+                Log.d(TAG, "Recognition result: NoMatches")
+            }
+            is RecognitionResult.ScheduledOffline -> {
+                Log.d(TAG, "Recognition result: ScheduledOffline")
+            }
         }
     }
 

--- a/feature/recognition/src/main/java/com/mrsep/musicrecognizer/feature/recognition/service/AutoRecognitionTileService.kt
+++ b/feature/recognition/src/main/java/com/mrsep/musicrecognizer/feature/recognition/service/AutoRecognitionTileService.kt
@@ -1,0 +1,125 @@
+package com.mrsep.musicrecognizer.feature.recognition.service
+
+import android.annotation.SuppressLint
+import android.app.PendingIntent
+import android.content.ComponentName
+import android.content.Context
+import android.graphics.drawable.Icon
+import android.os.Build
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+import android.util.Log
+import com.mrsep.musicrecognizer.core.domain.preferences.PreferencesRepository
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import com.mrsep.musicrecognizer.core.strings.R as StringsR
+import com.mrsep.musicrecognizer.core.ui.R as UiR
+
+private const val TAG = "AutoRecognitionTileService"
+
+@AndroidEntryPoint
+class AutoRecognitionTileService : TileService() {
+
+    private var coroutineScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+    private var tileUpdateJob: Job? = null
+
+    @Inject
+    lateinit var preferencesRepository: PreferencesRepository
+
+    override fun onDestroy() {
+        super.onDestroy()
+        coroutineScope.cancel()
+    }
+
+    override fun onTileAdded() {
+        super.onTileAdded()
+        requestListeningState(this)
+    }
+
+    override fun onStartListening() {
+        super.onStartListening()
+        updateTile()
+    }
+
+    override fun onStopListening() {
+        super.onStopListening()
+        tileUpdateJob?.cancel()
+        tileUpdateJob = null
+    }
+
+    @SuppressLint("StartActivityAndCollapseDeprecated")
+    override fun onClick() {
+        super.onClick()
+        if (AutoRecognitionService.isRunning) {
+            AutoRecognitionService.stop(applicationContext)
+            coroutineScope.launch {
+                preferencesRepository.setAutoRecognizeEnabled(false)
+            }
+            tileUpdateJob = coroutineScope.launch {
+                kotlinx.coroutines.delay(500)
+                updateTile()
+            }
+        } else {
+            // Must launch through an activity to get foreground state for microphone FGS
+            coroutineScope.launch {
+                preferencesRepository.setAutoRecognizeEnabled(true)
+            }
+            if (Build.VERSION.SDK_INT >= 34) {
+                startActivityAndCollapse(
+                    PendingIntent.getActivity(
+                        applicationContext,
+                        0,
+                        AutoRecognitionLauncherActivity.startIntent(applicationContext),
+                        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+                    )
+                )
+            } else {
+                @Suppress("DEPRECATION")
+                startActivityAndCollapse(
+                    AutoRecognitionLauncherActivity.startIntent(applicationContext)
+                )
+            }
+            tileUpdateJob = coroutineScope.launch {
+                kotlinx.coroutines.delay(1500)
+                updateTile()
+            }
+        }
+    }
+
+    private fun updateTile() {
+        val tile = qsTile ?: run {
+            Log.e(TAG, "qsTile is null, is update called in valid state?")
+            return
+        }
+
+        tile.label = getString(
+            if (AutoRecognitionService.isRunning) {
+                StringsR.string.auto_recognize_tile_active
+            } else {
+                StringsR.string.auto_recognize_tile_inactive
+            }
+        )
+        tile.state = if (AutoRecognitionService.isRunning) Tile.STATE_ACTIVE else Tile.STATE_INACTIVE
+        tile.icon = Icon.createWithResource(this, UiR.drawable.ic_auto_recognize)
+        tile.updateTile()
+    }
+
+    companion object {
+        fun requestListeningState(context: Context) {
+            try {
+                requestListeningState(
+                    context.applicationContext,
+                    ComponentName(context.applicationContext, AutoRecognitionTileService::class.java)
+                )
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to request qsTile listening state", e)
+            }
+        }
+    }
+}

--- a/feature/recognition/src/main/java/com/mrsep/musicrecognizer/feature/recognition/service/RecognitionControlActivity.kt
+++ b/feature/recognition/src/main/java/com/mrsep/musicrecognizer/feature/recognition/service/RecognitionControlActivity.kt
@@ -153,6 +153,10 @@ class RecognitionControlActivity : ComponentActivity() {
                 Log.w(this::class.java.simpleName, "AudioPlaybackCapture API is available on Android 10+")
                 finish()
             }
+            AudioCaptureMode.AutoRecognizer -> {
+                // Auto Recognition is handled in RecognitionScreen, not here
+                finish()
+            }
         }
     }
 
@@ -296,4 +300,5 @@ internal fun AudioCaptureMode.toServiceMode(mediaProjectionData: Intent?) = when
     AudioCaptureMode.Microphone -> AudioCaptureServiceMode.Microphone
     AudioCaptureMode.Device -> AudioCaptureServiceMode.Device(mediaProjectionData)
     AudioCaptureMode.Auto -> AudioCaptureServiceMode.Auto(mediaProjectionData)
+    AudioCaptureMode.AutoRecognizer -> AudioCaptureServiceMode.Microphone // Fallback, not actually used
 }

--- a/feature/recognition/src/main/java/com/mrsep/musicrecognizer/feature/recognition/widget/RecognitionWidget.kt
+++ b/feature/recognition/src/main/java/com/mrsep/musicrecognizer/feature/recognition/widget/RecognitionWidget.kt
@@ -178,6 +178,7 @@ internal class LaunchRecognition : ActionCallback {
             AudioCaptureMode.Microphone -> true
             AudioCaptureMode.Device,
             AudioCaptureMode.Auto -> preferences.useAltDeviceSoundSource
+            AudioCaptureMode.AutoRecognizer -> true
         }
         val skipPermissionsRequests = skipMediaProjectionRequest &&
                 context.checkPermissionsGranted(getRequiredPermissionsForRecognition())


### PR DESCRIPTION
## Summary

I saw in Issue #20 a couple years ago that someone wanted this implementation in, but the main issue was the API cost and when users only got the aftermentioned 2-4 requests per day as using an Auto-Recognition feature would be impractical. Now that the app uses Shazam fingerprinting and doesn't have a per-request api call, the Auto Recognition can be easily implemented :D

## General description of how auto recognition works

A foreground service uses `AutoRecognitionService` that runs in the background continuously identifying songs using the user's default audio capture mode, but if you have it set to "Device" or "Automatic" I currently have it set-up to where it will only grab the visualizer api since using continuous mode + device audio (screen recording) was rather inconvenient and very wasteful on battery & cpu. So even if you don't have the "Use alternative device audio source" checked, the `AutoRecognitionService` will default to the visualizer api still.

You can currently activate the `AutoRecognitionService` by using the **Quick Settings tile** or by **long-pressing the main recognition button** when you have the "AutoRecognition" option selected from the "Button Long Press" dropdown in the Audio source section. You may have a different idea of implementing this, but to me this made the most sense since putting it there.

When a new song is recognized by the `AutoRecognitionService`, just like the regular single recognition mode, a notification will appear; notifications for recurring song finds will also be added automatically to the notification card list.

You can turn off the `AutoRecognitionService` by tapping the floating noticiation and pressing "cancel", by pressing the quick settings tile, or by going into the app itself again and turning it off the same way you would turn of the regular recognition feature.

Just like shazam, duplicate detections of the same song are suppressed.

There are 10 second intervals between recognition cycles, and each cycle lasts as long as the visualizer api + recognition provider needs to process it.

## General description of added components

- `AutoRecognitionService` — foreground service that continuously identifies songs in the background
- `AutoRecognitionTileService` — Quick Settings tile for toggling auto-recognition on/off
- `AutoRecognitionLauncherActivity` — transparent activity needed to start the foreground service on Android 14+
- `AutoRecognizer` — new audio capture mode added to the enum, proto schema, and preference mappers
- `autoRecognizeEnabled` — new preference field to persist the service's on/off state
- Auto Recognition is only selectable in the "Button Long Press" audio source dropdown, not in "Default"
- Added exhaustive case handling for the new mode in `RecognitionControlActivity` and `RecognitionWidget`
- New string resources for notifications, toasts, and tile labels

## Screenshots / Demo

### Video demo

https://github.com/user-attachments/assets/e2e25dbf-ae29-4792-9386-833b9c096fba

### Screenshots

<p>
<img src="https://github.com/user-attachments/assets/c98d4288-226a-4137-930d-834667f14193" width="200">
<img src="https://github.com/user-attachments/assets/75d1fe1e-177e-416b-8018-273c3ebf9028" width="200">
<img src="https://github.com/user-attachments/assets/90733655-68d4-4a50-9a3e-dd4da5bea741" width="200">
<img src="https://github.com/user-attachments/assets/e1ce8cf4-db0f-44e3-ad9e-b0fb3a3c40a7" width="200">
<img src="https://github.com/user-attachments/assets/48b0e8b4-6440-4589-b497-48da0312e6c1" width="200">
<img src="https://github.com/user-attachments/assets/12bbae3f-7e35-4c3a-9ab4-bd4e2ad15942" width="200">
</p>